### PR TITLE
added functionality to include comment count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -96,7 +96,7 @@ describe("App", () => {
           .get("/api/articles/1")
           .expect(200)
           .then(({ body }) => {
-            expect(Object.keys(body).length).toEqual(7);
+            expect(Object.keys(body).length).toEqual(8);
             expect(typeof body).toEqual("object");
           });
       });
@@ -111,6 +111,7 @@ describe("App", () => {
               article_id: 1,
               author: "butter_bridge",
               body: "I find this existence challenging",
+              comment_count: "11",
               created_at: "2020-07-09T21:11:00.000Z",
               title: "Living in the shadow of a great man",
               topic: "mitch",
@@ -127,6 +128,7 @@ describe("App", () => {
               article_id: 3,
               author: "icellusedkars",
               body: "some gifs",
+              comment_count: "2",
               created_at: "2020-11-03T09:12:00.000Z",
               title: "Eight pug gifs that remind me of mitch",
               topic: "mitch",
@@ -210,7 +212,6 @@ describe("App", () => {
         });
     });
   });
-
   describe("GET /api/users", () => {
     test("Status 200: response to be an array of objects of length 3", () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -119,6 +119,23 @@ describe("App", () => {
             });
           });
       });
+      test("Article with 0 comments correctly returns", () => {
+        return request(app)
+          .get("/api/articles/4")
+          .expect(200)
+          .then(({ body }) => {
+            expect(body).toEqual({
+              article_id: 4,
+              author: "rogersop",
+              body: "We all love Mitch and his wonderful, unique typing style. However, the volume of his typing has ALLEGEDLY burst another students eardrums, and they are now suing for damages",
+              comment_count: "0",
+              created_at: "2020-05-06T02:14:00.000Z",
+              title: "Student SUES Mitch!",
+              topic: "mitch",
+              votes: 0,
+            });
+          });
+      });
       test("Correct data should be returned for ID 3", () => {
         return request(app)
           .get("/api/articles/3")

--- a/models/models.js
+++ b/models/models.js
@@ -15,7 +15,7 @@ exports.getArticleByIDModel = (id) => {
       ` SELECT articles.*,
         COUNT(comments.article_id) AS comment_count
         FROM articles
-        INNER JOIN comments
+        LEFT JOIN comments
         ON articles.article_id = comments.article_id
         WHERE articles.article_id = $1
         GROUP BY articles.article_id;`,

--- a/models/models.js
+++ b/models/models.js
@@ -11,14 +11,22 @@ exports.getArticleByIDModel = (id) => {
     return Promise.reject({ status: 400, msg: "Invalid ID" });
   }
   return db
-    .query(`SELECT *  from articles WHERE article_id = $1;`, [id])
+    .query(
+      ` SELECT articles.*,
+        COUNT(comments.article_id) AS comment_count
+        FROM articles
+        INNER JOIN comments
+        ON articles.article_id = comments.article_id
+        WHERE articles.article_id = $1
+        GROUP BY articles.article_id;`,
+      [id]
+    )
     .then((result) => {
       if (result.rows.length != 0) {
         return result.rows;
       } else return Promise.reject({ status: 404, msg: "ID Doesn't Exist" });
     });
 };
-
 
 exports.updateArticleByIdModel = (article_id, newVote) => {
   if (Object.keys(newVote).length > 1) {
@@ -53,4 +61,3 @@ exports.getUsersModel = () => {
     return result.rows;
   });
 };
-


### PR DESCRIPTION
Added functionality to the GET /api/articles/:article_id endpoint so the response object now includes a comment count. The tests have been updated to reflect this as well.